### PR TITLE
Chore: 일일 오픈 PR 현황 Slack 알림 워크플로우 추가

### DIFF
--- a/.github/workflows/daily_pr_summary.yml
+++ b/.github/workflows/daily_pr_summary.yml
@@ -1,0 +1,77 @@
+name: Daily Open Pull Request Summary
+
+on:
+  schedule:
+    - cron: '0 10 * * *' # 오후
+  workflow_dispatch:
+
+jobs:
+  send_daily_summary:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Get Open Pull Requests and Generate Slack Payload
+        id: generate_payload
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+          gh pr list --state open --json number,title,url,author,labels --limit 100 > pr_list.json
+
+          PR_LIST_JSON=$(cat pr_list.json)
+
+          SLACK_PAYLOAD=$(echo "$PR_LIST_JSON" | jq -c '
+            if length == 0 then
+              {
+                "text": "✨ 현재 오픈된 Pull Request가 없습니다! ✨",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "✨ *훌륭합니다! 현재 오픈된 Pull Request가 없습니다.* ✨"
+                    }
+                  }
+                ]
+              }
+            else
+              {
+                "text": "금일 오픈된 Pull Request 목록",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": ":mega: *금일 오픈된 Pull Request 목록* :mega:"
+                    }
+                  }
+                ] +
+                (
+                  map({
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      text: (
+                          let deadline_labels = (.labels | map(select(.name | test("^D-[0-3]$|^overdue$")) | .name) | sort | join(", "));
+                          "- *#\(.number)* <\(.url)|\(.title)> by \(.author.login)\((if deadline_labels == "" then "" else " [기한: \(deadline_labels)]" end))"
+                      )
+                    }
+                  })
+                )
+              }
+            end
+          ')
+
+          echo "payload=$SLACK_PAYLOAD" >> $GITHUB_OUTPUT
+
+      - name: Send Daily PR Summary to Slack
+        if: ${{ steps.generate_payload.outcome == 'success' }}
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: ${{ steps.generate_payload.outputs.payload }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/daily_pr_summary.yml
+++ b/.github/workflows/daily_pr_summary.yml
@@ -2,7 +2,7 @@ name: Daily Open Pull Request Summary
 
 on:
   schedule:
-    - cron: '0 10 * * *' # 오후
+    - cron: '0 10 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/daily_pr_summary.yml
+++ b/.github/workflows/daily_pr_summary.yml
@@ -2,7 +2,7 @@ name: Daily Open Pull Request Summary
 
 on:
   schedule:
-    - cron: '0 10 * * *'
+    - cron: '0 10 * * *' # Runs at 19:00 KST
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/daily_pr_summary.yml
+++ b/.github/workflows/daily_pr_summary.yml
@@ -14,6 +14,8 @@ jobs:
       pull-requests: read
 
     steps:
+      - name: Check Out Repository
+        uses: actions/checkout@v3
       - name: Get Open Pull Requests and Generate Slack Payload
         id: generate_payload
         run: |


### PR DESCRIPTION
## ✨ Feat: 일일 오픈 PR 현황 파악하여 Slack으로 알려주는 워크플로우 도입
* 이 PR은 GitHub Actions를 활용하여 현재 오픈된 Pull Request (PR) 목록을 매일 Slack 채널로 요약하여 전송하는 기능을 추가해요.

## 📝 배경 및 필요성
* 코드 리뷰 가시성 증대: 팀원들이 주기적으로 오픈된 PR 현황을 확인하여 리뷰를 놓치거나 잊는 일을 방지합니다.
* PR 처리 효율 향상: 장기 미처리 PR 발생 가능성을 줄이고, 병목 현상을 조기에 식별하여 빠르게 해결할 수 있도록 돕습니다.
* 커뮤니케이션 간소화: 수동으로 PR 현황을 공유할 필요를 줄여 팀의 전반적인 업무 효율성을 높입니다.
## 🚀 주요 변경 사항
 * `.github/workflows/daily_pr_summary.yml` 파일 추가:
    * **매일 오후 7시로 Slack으로 알림 전송**
    * GitHub Actions UI에서 **수동으로 워크플로우 실행 가능** (`workflow_dispatch`).
    * 열려 있는 PR이 없을 경우 "현재 오픈된 PR이 없습니다!" 메시지 전송.
    * PR이 있을 경우, 각 PR의 번호, 제목, 링크, 작성자, 그리고 **D-day 및 overdue 라벨 정보**를 포함하여 전송.

## 🔍 리뷰어 가이드
* feat/slack-bot 브랜치에서 workflow-dispatch로 workflow가 작동되지 않아 머지 후 테스트 해보려해요. 
미작동 시 다시 PR 올리겠습니다.
## 📎 관련 이슈 / 링크
* [GitHub Actions cron 스케줄](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule)
* [Slack API: App 생성 및 토큰 발급](https://api.slack.com/apps)

## 🙋 기타 공유 사항
* 이 워크플로우를 사용하려면 GitHub 저장소의 Settings > Secrets and variables > Actions에 다음 두 가지 Secret이 설정되어야 합니다:
* SLACK_CHANNEL_ID (메시지를 받을 Slack 채널의 고유 ID)
* SLACK_BOT_TOKEN (Slack 앱의 Bot User OAuth Token, chat:write 스코프 필요)
* 설정 후 GitHub Actions 탭에서 수동으로 워크플로우를 실행하여 정상 작동 여부를 테스트해 보실 수 있습니다.
----
* 현재 Secret 2개 모두 설정되어 있어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 매일 오후 7시에 오픈된 Pull Request 목록을 자동으로 요약하여 슬랙 채널로 전송하는 워크플로우가 추가되었습니다.
  - PR의 번호, 제목, 작성자, 마감 관련 라벨 정보가 포함된 메시지가 발송됩니다.
  - 오픈된 PR이 없을 경우 해당 안내 메시지가 전송됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->