### PR TITLE
Add user decorator, Edit UserRole

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,4 +39,10 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    files: ['**/*.spec.ts', '**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/unbound-method': 'off',
+    },
+  },
 );

--- a/src/common/decorator/current-user.decorator.ts
+++ b/src/common/decorator/current-user.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { User } from '@/users/entities/user.entity';
+
+export const CurrentUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): User => {
+    const request = ctx.switchToHttp().getRequest<{ user: User }>();
+    return request.user;
+  },
+);

--- a/src/common/enums/user-role.ts
+++ b/src/common/enums/user-role.ts
@@ -1,4 +1,4 @@
 export enum UserRole {
-  HOST = 'HOST',
-  GUEST = 'GUEST',
+  ADMIN = 'admin',
+  USER = 'user',
 }

--- a/src/common/guard/global-auth.guard.spec.ts
+++ b/src/common/guard/global-auth.guard.spec.ts
@@ -30,9 +30,7 @@ describe('GlobalAuthGuard', () => {
   });
 
   it('should deny access if user is not authenticated', () => {
-    jest
-      .spyOn(reflector, 'getAllAndOverride')
-      .mockReturnValue([UserRole.GUEST]);
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([UserRole.USER]);
 
     const mockContext = {
       getHandler: jest.fn(),
@@ -48,9 +46,7 @@ describe('GlobalAuthGuard', () => {
   });
 
   it('should allow access if user has the required role', () => {
-    jest
-      .spyOn(reflector, 'getAllAndOverride')
-      .mockReturnValue([UserRole.GUEST]);
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([UserRole.USER]);
 
     const mockContext = {
       getHandler: jest.fn(),
@@ -58,7 +54,7 @@ describe('GlobalAuthGuard', () => {
       switchToHttp: jest.fn().mockReturnValue({
         getRequest: jest
           .fn()
-          .mockReturnValue({ user: { role: UserRole.GUEST } }),
+          .mockReturnValue({ user: { role: UserRole.USER } }),
       }),
     } as unknown as ExecutionContext;
 
@@ -67,7 +63,9 @@ describe('GlobalAuthGuard', () => {
   });
 
   it('should deny access if user does not have the required role', () => {
-    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([UserRole.HOST]);
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([UserRole.ADMIN]);
 
     const mockContext = {
       getHandler: jest.fn(),
@@ -75,7 +73,7 @@ describe('GlobalAuthGuard', () => {
       switchToHttp: jest.fn().mockReturnValue({
         getRequest: jest
           .fn()
-          .mockReturnValue({ user: { role: UserRole.GUEST } }),
+          .mockReturnValue({ user: { role: UserRole.USER } }),
       }),
     } as unknown as ExecutionContext;
 

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -23,7 +23,7 @@ export class User extends BaseEntity {
   @Column({
     type: 'enum',
     enum: UserRole,
-    default: UserRole.GUEST,
+    default: UserRole.USER,
   })
   role: UserRole;
 


### PR DESCRIPTION
## 💡 주요 변경사항

- 토큰에서 파싱한 유저를 controller에서 사용하기 위한 커스텀 데코레이터 추가
- 테스트코드 린트 설정 변경
- UserRole 종류 변경
    - 이전 PR에서 놓쳤었는데, UserRole은 회원등급 개념이라 Guest, host 개념이 없습니다.
    - 우리 서비스에는 사실 회원등급 개념이 없어서 USER 만 놓고 사용해도 되는데, 혹시 나중에라도 어드민 유저가 필요할까봐 남겨놨구요
    - UserRole.USER만 있다고 생각하고 개발해도 무방합니다.
    - Guest, host 개념은 UserRervation 엔티티에 role 컬럼으로 들어가야할 것 같아서, 이 부분은 나중에 관련 api 작업하는 사람이 추가하면 될 것 같아요

## 🔍 리뷰어 가이드

- 궁금한 점이나 좋은 의견이 있다면 자유롭게 남겨주세여

## 📎 관련 이슈 / 링크

-

## 🙋 기타 공유 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 인증된 사용자를 컨트롤러에서 쉽게 주입할 수 있는 `CurrentUser` 데코레이터가 추가되었습니다.
- **버그 수정**
	- 테스트 파일에 한해 특정 ESLint 규칙이 비활성화되어, 코드 검사 오류가 줄어들었습니다.
- **리팩터**
	- 사용자 역할이 `ADMIN`, `USER`로 변경되었으며, 문자열 표기도 소문자로 바뀌었습니다.
	- 신규 사용자 생성 시 기본 역할이 `USER`로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->