### PR TITLE
#52 [FEATURE] FCM 토큰 업데이트 API 추가

### DIFF
--- a/src/migrations/1751105211041-AddFcmTokenToUsers.ts
+++ b/src/migrations/1751105211041-AddFcmTokenToUsers.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddFcmTokenToUsers1751105211041 implements MigrationInterface {
+  name = 'AddFcmTokenToUsers1703123456789';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'users',
+      new TableColumn({
+        name: 'fcmToken',
+        type: 'varchar',
+        length: '255',
+        isNullable: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('users', 'fcmToken');
+  }
+}

--- a/src/migrations/1751105211041-AddFcmTokenToUsers.ts
+++ b/src/migrations/1751105211041-AddFcmTokenToUsers.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 
 export class AddFcmTokenToUsers1751105211041 implements MigrationInterface {
-  name = 'AddFcmTokenToUsers1703123456789';
+  name = 'AddFcmTokenToUsers1751105211041';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.addColumn(

--- a/src/users/dto/request/update-fcm-token.dto.ts
+++ b/src/users/dto/request/update-fcm-token.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateFcmTokenDto {
+  @ApiProperty({
+    description: 'FCM 토큰',
+    example: 'fcm_token_example',
+    required: true,
+    type: String,
+  })
+  @IsString()
+  @IsNotEmpty()
+  fcmToken: string;
+}

--- a/src/users/dto/request/update-fcm-token.dto.ts
+++ b/src/users/dto/request/update-fcm-token.dto.ts
@@ -4,7 +4,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class UpdateFcmTokenDto {
   @ApiProperty({
     description: 'FCM 토큰',
-    example: 'fcm_token_example',
+    example: 'fcmTokenExample',
     required: true,
     type: String,
   })

--- a/src/users/dto/response/update-fcm-token-response.dto.ts
+++ b/src/users/dto/response/update-fcm-token-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from '@/users/entities/user.entity';
+
+export class UpdateFcmTokenResponseDto {
+  @ApiProperty({
+    description: '사용자 ID',
+    example: 123,
+  })
+  userId: number;
+
+  @ApiProperty({
+    description: 'FCM 토큰',
+    example: 'fcm_token_example',
+  })
+  fcmToken: string | null;
+
+  constructor(user: User) {
+    this.userId = user.id;
+    this.fcmToken = user.fcmToken;
+  }
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -32,4 +32,7 @@ export class User extends BaseEntity {
 
   @Column({ name: 'kok_alarm_setting', type: 'boolean', default: true })
   kokAlarmSetting: boolean;
+
+  @Column({ name: 'fcm_token', nullable: true })
+  fcmToken: string | null;
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -33,6 +33,6 @@ export class User extends BaseEntity {
   @Column({ name: 'kok_alarm_setting', type: 'boolean', default: true })
   kokAlarmSetting: boolean;
 
-  @Column({ name: 'fcm_token', nullable: true })
+  @Column({ name: 'fcm_token', type: 'text', nullable: true })
   fcmToken: string | null;
 }

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -7,6 +7,7 @@ import { UserNotFoundException } from '@/common/exception/user.exception';
 import { getProfileImagePath } from '@/common/enums/profile-image-code';
 import { UserStatisticsService } from './user-statistics.service';
 import { FilesService } from '@/files/files.service';
+import { UpdateFcmTokenResponseDto } from '@/users/dto/response/update-fcm-token-response.dto';
 
 @Injectable()
 export class UsersService {
@@ -46,6 +47,21 @@ export class UsersService {
     }
 
     const response = new UpdateUserSettingsResponseDto(updatedUser);
+    return response;
+  }
+
+  async updateFcmToken(
+    userId: number,
+    fcmToken: string,
+  ): Promise<UpdateFcmTokenResponseDto> {
+    const user = await this.usersRepository.findUserById(userId);
+    if (!user) {
+      throw new UserNotFoundException();
+    }
+
+    await this.usersRepository.updateFcmToken(userId, fcmToken);
+
+    const response = new UpdateFcmTokenResponseDto(user);
     return response;
   }
 }

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -60,7 +60,7 @@ export class UsersService {
     }
 
     await this.usersRepository.updateFcmToken(userId, fcmToken);
-
+    user.fcmToken = fcmToken;
     const response = new UpdateFcmTokenResponseDto(user);
     return response;
   }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -131,7 +131,7 @@ export class UsersController {
   @Patch('fcm-token')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
-    summary: 'FCM 토큰 업데이트',
+    summary: 'FCM 토큰 업데이트 ✅',
     description:
       '클라이언트로부터 FCM 토큰을 받아 사용자의 FCM 토큰을 업데이트합니다.',
   })

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -28,6 +28,8 @@ import { ApiAuth } from '@/common/decorator/api.auth.decorator';
 import { ApiErrorResponse } from '@/common/decorator/api-error-response.decorator';
 import { InvalidTokenException } from '@/common/exception/auth.exception';
 import { UserNotFoundException } from '@/common/exception/user.exception';
+import { UpdateFcmTokenDto } from '@/users/dto/request/update-fcm-token.dto';
+import { UpdateFcmTokenResponseDto } from '@/users/dto/response/update-fcm-token-response.dto';
 
 @ApiTags('사용자')
 @Controller('users')
@@ -124,5 +126,25 @@ export class UsersController {
     @CurrentUser() user: User,
   ): Promise<UpdateUserSettingsResponseDto> {
     return await this.usersService.updateUserSettings(user.id, updateDto);
+  }
+
+  @Patch('fcm-token')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'FCM 토큰 업데이트',
+    description:
+      '클라이언트로부터 FCM 토큰을 받아 사용자의 FCM 토큰을 업데이트합니다.',
+  })
+  @ApiErrorResponse(InvalidTokenException)
+  @ApiErrorResponse(UserNotFoundException)
+  @CommonResponseDecorator(UpdateFcmTokenResponseDto)
+  async updateFcmToken(
+    @Body() updateFcmTokenDto: UpdateFcmTokenDto,
+    @CurrentUser() user: User,
+  ): Promise<UpdateFcmTokenResponseDto> {
+    return await this.usersService.updateFcmToken(
+      user.id,
+      updateFcmTokenDto.fcmToken,
+    );
   }
 }

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -122,7 +122,7 @@ export class UsersRepository extends Repository<User> {
     });
   }
 
-  async updateFcmToken(id: number, fcmToken: string): Promise<void> {
-    await this.update(id, { fcmToken });
+  async updateFcmToken(userId: number, fcmToken: string): Promise<void> {
+    await this.update(userId, { fcmToken });
   }
 }

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -121,4 +121,8 @@ export class UsersRepository extends Repository<User> {
       select: selectOptions,
     });
   }
+
+  async updateFcmToken(id: number, fcmToken: string): Promise<void> {
+    await this.update(id, { fcmToken });
+  }
 }


### PR DESCRIPTION
## 💡 주요 변경사항

FCM 토큰 업데이트 api 추가했어요

## 🔍 리뷰어 가이드

FCM 발송 실패시 해당 유저 fcm 토큰 제거를 하기 위해 해당 api 먼저 pr 올려요.

## 📎 관련 이슈 / 링크

resolves #52 

## 🙋 기타 공유 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 FCM(Firebase Cloud Messaging) 토큰을 업데이트할 수 있는 PATCH API 엔드포인트가 추가되었습니다.
  * 사용자 정보에 FCM 토큰 저장 기능이 추가되었습니다.
  * FCM 토큰 업데이트 요청 및 응답에 대한 API 문서가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->