### PR TITLE
Add get profile image codes API

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { SimilarGroupsModule } from './similar-groups/similar-groups.module';
 import { FilesModule } from './files/files.module';
 import { ReservationsModule } from './reservations/reservations.module';
 import { FirebaseModule } from './firebase/firebase.module';
+import { CodesModule } from './codes/codes.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { FirebaseModule } from './firebase/firebase.module';
     FilesModule,
     ReservationsModule,
     FirebaseModule,
+    CodesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/codes/codes.controller.ts
+++ b/src/codes/codes.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ProfileImageCodeDto } from './dto/profile-image-code.dto';
+import {
+  PROFILE_IMAGE_PATH_MAP,
+  ProfileImageCode,
+} from '@/common/enums/profile-image-code';
+import { FilesService } from '@/files/files.service';
+import { CommonResponseDecorator } from '@/common/decorator/common.response.decorator';
+
+@ApiTags('Codes')
+@Controller('codes')
+export class CodesController {
+  constructor(private readonly fileService: FilesService) {}
+
+  @Get('profile-image-code')
+  @ApiOperation({
+    summary: '프로필 종류 조회 ✅',
+  })
+  @CommonResponseDecorator(ProfileImageCodeDto)
+  async getProfileImageCodes(): Promise<ProfileImageCodeDto[]> {
+    return Promise.all(
+      Object.values(ProfileImageCode).map(
+        async (code) =>
+          new ProfileImageCodeDto(
+            code,
+            await this.fileService.getAccessPresignedUrl(
+              PROFILE_IMAGE_PATH_MAP[code],
+            ),
+          ),
+      ),
+    );
+  }
+}

--- a/src/codes/codes.module.ts
+++ b/src/codes/codes.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CodesController } from './codes.controller';
+import { FilesModule } from '@/files/files.module';
+
+@Module({
+  imports: [FilesModule],
+  controllers: [CodesController],
+})
+export class CodesModule {}

--- a/src/codes/dto/profile-image-code.dto.ts
+++ b/src/codes/dto/profile-image-code.dto.ts
@@ -1,0 +1,21 @@
+import { ProfileImageCode } from '@/common/enums/profile-image-code';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProfileImageCodeDto {
+  @ApiProperty({
+    description: '코드 이름',
+    enum: ProfileImageCode,
+  })
+  profileImageCodeName: ProfileImageCode;
+
+  @ApiProperty({
+    description: '프로필 이미지 조회 presigned URL',
+    example: 'http://abced',
+  })
+  imageUrl: string;
+
+  constructor(code: ProfileImageCode, url: string) {
+    this.profileImageCodeName = code;
+    this.imageUrl = url;
+  }
+}

--- a/src/common/enums/profile-image-code.ts
+++ b/src/common/enums/profile-image-code.ts
@@ -7,11 +7,11 @@ export enum ProfileImageCode {
 }
 
 export const PROFILE_IMAGE_PATH_MAP: Record<ProfileImageCode, string> = {
-  [ProfileImageCode.PURPLE]: 'profile-images/IMG_001.png',
-  [ProfileImageCode.ORANGE]: 'profile-images/IMG_002.png',
-  [ProfileImageCode.GREEN]: 'profile-images/IMG_003.png',
-  [ProfileImageCode.BLUE]: 'profile-images/IMG_004.png',
-  [ProfileImageCode.PINK]: 'profile-images/IMG_005.png',
+  [ProfileImageCode.PURPLE]: '/profile-images/IMG_001.png',
+  [ProfileImageCode.ORANGE]: '/profile-images/IMG_002.png',
+  [ProfileImageCode.GREEN]: '/profile-images/IMG_003.png',
+  [ProfileImageCode.BLUE]: '/profile-images/IMG_004.png',
+  [ProfileImageCode.PINK]: '/profile-images/IMG_005.png',
 };
 
 export const getProfileImagePath = (


### PR DESCRIPTION
## 💡 주요 변경사항

프로필 이미지 전체 종류를 조회할 수 있는 api를 추가합니다.

## 🔍 리뷰어 가이드

s3 프로필 이미지 경로에 우선 더미 이미지 저장해놨습니다.
ex) /profile-images/IMG_001.png

## 📎 관련 이슈 / 링크

closed #78 

## 🙋 기타 공유 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 프로필 이미지 코드와 해당 이미지의 presigned URL을 제공하는 새로운 API 엔드포인트가 추가되었습니다.

* **기타**
  * 프로필 이미지 경로의 형식이 슬래시(`/`)로 시작하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->