### PR TITLE
fix: 예약 카테고리 예시 영어로 수정

### DIFF
--- a/src/docs/dto/reservation.dto.ts
+++ b/src/docs/dto/reservation.dto.ts
@@ -22,7 +22,7 @@ export class CreateReservationResponse {
 
   @ApiProperty({
     description: '예약 카테고리',
-    example: '맛집',
+    example: 'FOOD',
   })
   category: string;
 
@@ -113,7 +113,7 @@ export class ReservationSummaryDto {
 
   @ApiProperty({
     description: '예약 카테고리',
-    example: '맛집',
+    example: 'FOOD',
   })
   category: string;
 

--- a/src/reservations/dto/request/create-reservation.request.ts
+++ b/src/reservations/dto/request/create-reservation.request.ts
@@ -26,7 +26,7 @@ export class CreateReservationRequest {
   @ApiProperty({
     enum: ReservationCategory,
     description: '예약 카테고리',
-    example: '맛집',
+    example: 'FOOD',
   })
   @IsEnum(ReservationCategory, {
     message: 'ReservationCategory enum이 아닙니다.',

--- a/src/reservations/dto/request/update-reservation.request.ts
+++ b/src/reservations/dto/request/update-reservation.request.ts
@@ -26,7 +26,7 @@ export class UpdateReservationRequest {
   @ApiProperty({
     enum: ReservationCategory,
     description: '예약 카테고리',
-    example: '공연',
+    example: 'PERFORMANCE',
     required: false,
   })
   @IsOptional()

--- a/src/reservations/dto/response/update-reservation.response.ts
+++ b/src/reservations/dto/response/update-reservation.response.ts
@@ -17,7 +17,7 @@ export class UpdateReservationResponse {
 
   @ApiProperty({
     description: '수정된 카테고리',
-    example: '공연',
+    example: 'PERFORMANCE',
   })
   category: string;
 

--- a/src/reservations/reservations.controller.ts
+++ b/src/reservations/reservations.controller.ts
@@ -346,7 +346,7 @@ export class ReservationsController {
       data: {
         reservationId: reservationId,
         title: '오아시스를 직접 본다니',
-        category: '공연',
+        category: 'PERFORMANCE',
         reservationDatetime: '2025-08-21T19:00:00+09:00',
         description: '1순위로 E열 선정하기. 만약에 안되면 H도 괜찮아요',
         linkUrl: 'https://example.com/reservation-link',


### PR DESCRIPTION
## 💡 주요 변경사항

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

## 🔍 리뷰어 가이드

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 📎 관련 이슈 / 링크

> ex) #이슈번호, #이슈번호

## 🙋 기타 공유 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 예약 관련 예시 값의 카테고리 표기를 기존 한글(예: '맛집', '공연')에서 영어 대문자(예: 'FOOD', 'PERFORMANCE')로 변경했습니다.  
  * 일부 응답에서 반환되는 카테고리 값도 영어 대문자로 통일되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->