### PR TITLE
예약 리스트 조회, 구성원들의 예약 결과 리스트 조회 목데이터 추가, 페이지네이션에 커서 삭제

### DIFF
--- a/src/docs/dto/reservation.dto.ts
+++ b/src/docs/dto/reservation.dto.ts
@@ -91,15 +91,6 @@ export class GetReservationsQueryDto extends BasePaginationQueryDto {
   @IsOptional()
   @IsIn(['before', 'after'])
   readonly status?: 'before' | 'after';
-
-  @ApiProperty({
-    description: '커서 (마지막 조회된 예약 ID)',
-    required: false,
-    example: 4,
-    type: 'number',
-  })
-  @IsOptional()
-  readonly cursor?: number;
 }
 
 export class ReservationItemDto {

--- a/src/reservations/dto/response/get-reservation-results.response.dto.ts
+++ b/src/reservations/dto/response/get-reservation-results.response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CreateReservationResultDto } from './create-reservation-result.dto';
+
+export class GetReservationResultsResponseDto {
+  @ApiProperty({
+    description: '호스트 정보',
+    type: CreateReservationResultDto,
+  })
+  host: CreateReservationResultDto;
+
+  @ApiProperty({
+    description: '예약 결과 목록',
+    type: [CreateReservationResultDto],
+  })
+  results: CreateReservationResultDto[];
+}

--- a/src/reservations/mock-reservations.data.ts
+++ b/src/reservations/mock-reservations.data.ts
@@ -1,0 +1,41 @@
+import { ReservationItemDto } from '@/docs/dto/reservation.dto';
+
+const NAMES = [
+  '이윤하',
+  '김바다',
+  '김아린',
+  '김남수',
+  '조재훈',
+  '유지인',
+  '신상우',
+  '박병호',
+  '이창환 (멧돼지)',
+  '조혜온',
+  '박서연',
+  '허거덩거덩스',
+  '화이팅',
+  '최고다',
+  '멋지다',
+  '잘한다',
+  '우승',
+  '가자ㅏ',
+];
+
+export const MOCK_RESERVATIONS: ReservationItemDto[] = Array.from({
+  length: 30,
+}).map((_, i) => {
+  const name = NAMES[i % NAMES.length];
+  return {
+    reservationId: i + 1,
+    title: name,
+    category: '운동경기',
+    reservationDatetime: `2025-07-${((i % 28) + 1).toString().padStart(2, '0')}T19:00:00+09:00`,
+    participantCount: Math.floor(Math.random() * 20) + 1,
+    maxParticipants: 20,
+    hostId: (i % NAMES.length) + 1,
+    hostNickname: name,
+    images: [`path/image${(i % 3) + 1}.jpg`],
+    userStatus: 'default',
+    isHost: i % 2 === 0,
+  };
+});

--- a/src/reservations/reservations.controller.ts
+++ b/src/reservations/reservations.controller.ts
@@ -15,7 +15,6 @@ import {
   ApiTags,
   ApiOperation,
   ApiResponse,
-  ApiBearerAuth,
   ApiParam,
   ApiQuery,
   ApiBody,
@@ -62,8 +61,11 @@ import { ValidationFailedException } from '@/common/exception/request-parsing.ex
 import { GetReservationMemberResponse } from './dto/response/get-reservation-member.response';
 import { ReservationMemberDto } from './dto/reservation-member.dto';
 import { GetReservationDetailResponse } from './dto/response/get-reservation-detail.response';
-import { CreateReservationResultDto } from './dto/response/create-reservation-result.dto';
 import { ReservationResultsService } from './reservation-results.service';
+import { ReservationResultStatus } from '@/common/enums/reservation-result-status';
+import { MOCK_RESERVATIONS } from './mock-reservations.data';
+import { OrderCondition } from '@/common/dto/request/pagination.dto';
+import { GetReservationResultsResponseDto } from './dto/response/get-reservation-results.response.dto';
 
 @ApiAuth()
 @ApiTags('예약')
@@ -144,9 +146,8 @@ export class ReservationsController {
 
   @Get()
   @HttpCode(HttpStatus.OK)
-  @ApiBearerAuth('JWT-auth')
   @ApiOperation({
-    summary: '예약 목록 - 예약정보',
+    summary: '예약 목록 - 예약정보 (💖목데이터 추가)',
     description:
       '현재 시간 기준으로 예약 목록을 조회합니다. before: 지난 예약, after: 예정된 예약',
   })
@@ -174,42 +175,34 @@ export class ReservationsController {
   getReservations(
     @Query() query: GetReservationsQueryDto,
   ): GetReservationsResponseDto {
-    const mockReservations = [
-      {
-        reservationId: 1,
-        title: '매쉬업 아구찜 직팬 모임',
-        category: '운동경기',
-        reservationDatetime: '2025-07-11T19:00:00+09:00',
-        participantCount: 3,
-        maxParticipants: 20,
-        hostId: 1,
-        hostNickname: '서연',
-        images: ['path/image1.jpg'],
-        userStatus: 'default',
-        isHost: false,
-      },
-      {
-        reservationId: 2,
-        title: '매쉬업 아구찜 직팬 모임',
-        category: '운동경기',
-        reservationDatetime: '2025-07-11T19:00:00+09:00',
-        participantCount: 3,
-        maxParticipants: 20,
-        hostId: 2,
-        hostNickname: '서연',
-        images: ['path/image1.jpg'],
-        userStatus: 'default',
-        isHost: true,
-      },
-    ];
-
-    const metadata = new PaginationMetadata(query.page, query.limit, 10);
-
+    // 오프셋 방식으로 목데이터 반환
+    const allReservations = MOCK_RESERVATIONS;
+    // 정렬
+    const sorted = [...allReservations].sort((a, b) => {
+      if (query.order === OrderCondition.ASC) {
+        return (
+          new Date(a.reservationDatetime).getTime() -
+          new Date(b.reservationDatetime).getTime()
+        );
+      } else {
+        return (
+          new Date(b.reservationDatetime).getTime() -
+          new Date(a.reservationDatetime).getTime()
+        );
+      }
+    });
+    const offset = (query.page - 1) * query.limit;
+    const pagedReservations = sorted.slice(offset, offset + query.limit);
+    const metadata = new PaginationMetadata(
+      query.page,
+      query.limit,
+      allReservations.length,
+    );
     return {
       code: '200',
       message: 'OK',
       data: {
-        reservations: mockReservations,
+        reservations: pagedReservations,
         metadata: metadata,
       },
     };
@@ -424,14 +417,14 @@ export class ReservationsController {
 
   @Get(':reservationId/results')
   @ApiOperation({
-    summary: '예약 결과 목록 조회',
+    summary: '구성원들의 예약 결과 목록 조회 (호스트 포함)(💖목데이터 추가))',
   })
   @ApiParam({
     name: 'reservationId',
     description: '예약 ID',
     example: '12345',
   })
-  @CommonResponseDecorator([CreateReservationResultDto])
+  @CommonResponseDecorator(GetReservationResultsResponseDto)
   @ApiResponse({
     status: 404,
     description: '본인이 속한 예약만 접근 가능',
@@ -452,7 +445,69 @@ export class ReservationsController {
       },
     },
   })
-  addReservationResults() {}
+  getReservationResults() {
+    // host 정보와 results 배열을 분리해서 반환
+    const host = {
+      reservationResultId: 1,
+      reservationId: 1,
+      userId: 1,
+      status: ReservationResultStatus.SUCCESS,
+      images: ['http://abc.com/image1.jpg'],
+      successDatetime: new Date('2025-07-11T19:00:00+09:00'),
+      description: '성공적으로 예약을 완료했습니다.',
+      createdAt: new Date('2025-07-11T19:00:00+09:00'),
+      updatedAt: new Date('2025-07-11T19:00:00+09:00'),
+    };
+    return {
+      host,
+      results: [
+        {
+          reservationResultId: 5,
+          reservationId: 1,
+          userId: 5,
+          status: ReservationResultStatus.SUCCESS,
+          images: ['http://abc.com/image1.jpg'],
+          successDatetime: new Date('2025-07-11T19:00:00+09:00'),
+          description: '성공적으로 예약을 완료했습니다.',
+          createdAt: new Date('2025-07-11T19:00:00+09:00'),
+          updatedAt: new Date('2025-07-11T19:00:00+09:00'),
+        },
+        {
+          reservationResultId: 2,
+          reservationId: 1,
+          userId: 2,
+          status: ReservationResultStatus.FAIL,
+          images: ['http://abc.com/image2.jpg'],
+          successDatetime: new Date('2025-07-11T19:00:00+09:00'),
+          description: '참여하지 못했습니다.',
+          createdAt: new Date('2025-07-11T19:00:00+09:00'),
+          updatedAt: new Date('2025-07-11T19:00:00+09:00'),
+        },
+        {
+          reservationResultId: 3,
+          reservationId: 1,
+          userId: 3,
+          status: ReservationResultStatus.HALF_SUCCESS,
+          images: ['http://abc.com/image3.jpg'],
+          successDatetime: new Date('2025-07-11T19:00:00+09:00'),
+          description: '절반만 성공했습니다.',
+          createdAt: new Date('2025-07-11T19:00:00+09:00'),
+          updatedAt: new Date('2025-07-11T19:00:00+09:00'),
+        },
+        {
+          reservationResultId: 4,
+          reservationId: 1,
+          userId: 4,
+          status: ReservationResultStatus.SUCCESS,
+          images: ['http://abc.com/image4.jpg'],
+          successDatetime: new Date('2025-07-11T19:00:00+09:00'),
+          description: '다시 성공!',
+          createdAt: new Date('2025-07-11T19:00:00+09:00'),
+          updatedAt: new Date('2025-07-11T19:00:00+09:00'),
+        },
+      ],
+    };
+  }
 
   @Get(':reservationId/results/rival_count')
   @ApiOperation({

--- a/src/reservations/reservations.controller.ts
+++ b/src/reservations/reservations.controller.ts
@@ -67,6 +67,7 @@ import { ReservationResultStatus } from '@/common/enums/reservation-result-statu
 import { MOCK_RESERVATIONS } from './mock-reservations.data';
 import { OrderCondition } from '@/common/dto/request/pagination.dto';
 import { GetReservationResultsResponseDto } from './dto/response/get-reservation-results.response.dto';
+import { CreateReservationResultDto } from './dto/response/create-reservation-result.dto';
 
 @ApiAuth()
 @ApiTags('예약')


### PR DESCRIPTION
## 💡 주요 변경사항

클라이언트의 빠른 작업을 위해 목데이터 추가했습니다.
💖 화이팅 💖

## 🔍 리뷰어 가이드
- 테스트 완료

## 📎 관련 이슈 / 링크

> ex) #이슈번호, #이슈번호

## 🙋 기타 공유 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 예약 결과 조회 시 호스트와 여러 예약 결과를 포함한 상세 모의 데이터를 반환하도록 개선되었습니다.
  * 예약 목록 조회 시 더 현실적인 모의 데이터와 오프셋 기반 페이지네이션, 정렬 기능이 적용되었습니다.

* **버그 수정**
  * 예약 목록 조회 쿼리에서 더 이상 cursor 필드를 사용하지 않습니다.

* **테스트**
  * 예약 관련 모의 데이터가 추가되어 테스트 및 개발 편의성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->