### PR TITLE
feat: 예약 결과 조회 API 요구사항 반영

### DIFF
--- a/src/common/constants/error-codes.ts
+++ b/src/common/constants/error-codes.ts
@@ -109,10 +109,6 @@ export const ERROR_CODES = {
     code: 2019,
     message: '이미 결과가 등록된 예약입니다.',
   },
-  CURRENT_USER_RESULT_NOT_FOUND: {
-    code: 2020,
-    message: '자신의 예약 결과를 먼저 등록해야 합니다.',
-  },
   // Firebase/알림 관련 (3000번대)
   INVALID_FCM_TOKEN: {
     code: 3000,

--- a/src/common/exception/reservation.exception.ts
+++ b/src/common/exception/reservation.exception.ts
@@ -73,9 +73,3 @@ export class ReservationAccessDeniedException extends BaseException {
     super(HttpStatus.FORBIDDEN, ERROR_CODES.RESERVATION_ACCESS_DENIED);
   }
 }
-
-export class CurrentUserResultNotFoundException extends BaseException {
-  constructor() {
-    super(HttpStatus.FORBIDDEN, ERROR_CODES.CURRENT_USER_RESULT_NOT_FOUND);
-  }
-}

--- a/src/reservations/dto/response/get-reservation-results.response.ts
+++ b/src/reservations/dto/response/get-reservation-results.response.ts
@@ -5,8 +5,9 @@ export class GetReservationResultsResponse {
   @ApiProperty({
     description: 'API를 요청한 현재 사용자의 예약 결과.',
     type: CreateReservationResultDto,
+    nullable: true,
   })
-  currentUser: CreateReservationResultDto;
+  currentUser: CreateReservationResultDto | null;
 
   @ApiProperty({
     description: '예약 결과 목록(자기 자신 제외)',
@@ -15,7 +16,7 @@ export class GetReservationResultsResponse {
   results: CreateReservationResultDto[];
 
   constructor(
-    currentUser: CreateReservationResultDto,
+    currentUser: CreateReservationResultDto | null,
     results: CreateReservationResultDto[],
   ) {
     this.currentUser = currentUser;

--- a/src/reservations/reservation-results.service.ts
+++ b/src/reservations/reservation-results.service.ts
@@ -123,7 +123,6 @@ export class ReservationResultsService {
   ): Promise<GetReservationResultsResponse> {
     await this.validateAccessAndGetReservation(reservationId, currentUserId);
 
-    // 현재 사용자 결과와 다른 참가자 결과를 조회합니다.
     const [currentUserResult, otherParticipantResults] = await Promise.all([
       this.reservationResultRepository.findOne({
         where: {

--- a/src/reservations/reservation-results.service.ts
+++ b/src/reservations/reservation-results.service.ts
@@ -14,7 +14,6 @@ import { ImageParentType } from '@/common/enums/image-parent-type';
 import { UserReservationStatus } from '@/common/enums/user-reservation-status';
 import { ReservationResultStatus } from '@/common/enums/reservation-result-status';
 import {
-  CurrentUserResultNotFoundException,
   ReservationAccessDeniedException,
   ReservationNotDoneException,
   ReservationNotFoundException,
@@ -124,38 +123,43 @@ export class ReservationResultsService {
   ): Promise<GetReservationResultsResponse> {
     await this.validateAccessAndGetReservation(reservationId, currentUserId);
 
-    const currentUserResult = await this.reservationResultRepository.findOne({
-      where: {
-        reservation: { id: reservationId },
-        user: { id: currentUserId },
-      },
-      relations: { user: true, reservation: true },
-    });
-
-    if (!currentUserResult) {
-      throw new CurrentUserResultNotFoundException();
-    }
-
-    const otherParticipantResults = await this.reservationResultRepository.find(
-      {
+    // 현재 사용자 결과와 다른 참가자 결과를 조회합니다.
+    const [currentUserResult, otherParticipantResults] = await Promise.all([
+      this.reservationResultRepository.findOne({
+        where: {
+          reservation: { id: reservationId },
+          user: { id: currentUserId },
+        },
+        relations: { user: true, reservation: true },
+      }),
+      this.reservationResultRepository.find({
         where: {
           reservation: { id: reservationId },
           user: { id: Not(currentUserId) },
         },
         relations: { user: true, reservation: true },
-      },
-    );
+      }),
+    ]);
 
-    const allResultIds = [
-      currentUserResult.id,
-      ...otherParticipantResults.map((r) => r.id),
-    ];
-    const imageUrlMap = await this.generateImageUrlMapForResults(allResultIds);
+    let currentUserResultDto: CreateReservationResultDto | null = null;
+    let imageUrlMap: Map<number, string[]> = new Map();
 
-    const currentUserResultDto = new CreateReservationResultDto(
-      currentUserResult,
-      imageUrlMap.get(currentUserResult.id) || null,
-    );
+    if (currentUserResult) {
+      const allResultIds = [
+        currentUserResult.id,
+        ...otherParticipantResults.map((r) => r.id),
+      ];
+      imageUrlMap = await this.generateImageUrlMapForResults(allResultIds);
+
+      currentUserResultDto = new CreateReservationResultDto(
+        currentUserResult,
+        imageUrlMap.get(currentUserResult.id) || null,
+      );
+    } else {
+      const otherResultIds = otherParticipantResults.map((r) => r.id);
+      imageUrlMap = await this.generateImageUrlMapForResults(otherResultIds);
+    }
+
     const otherParticipantResultDtos = otherParticipantResults.map(
       (result) =>
         new CreateReservationResultDto(

--- a/src/reservations/reservations.controller.ts
+++ b/src/reservations/reservations.controller.ts
@@ -54,7 +54,6 @@ import {
   ReservationNotDoneException,
   ReservationResultAlreadyExistsException,
   ReservationAccessDeniedException,
-  CurrentUserResultNotFoundException,
 } from '@/common/exception/reservation.exception';
 import { ValidationFailedException } from '@/common/exception/request-parsing.exception';
 import { GetReservationMemberResponse } from './dto/response/get-reservation-member.response';
@@ -393,7 +392,6 @@ export class ReservationsController {
   @CommonResponseDecorator(GetReservationResultsResponse)
   @ApiErrorResponse(ReservationAccessDeniedException)
   @ApiErrorResponse(ReservationNotDoneException)
-  @ApiErrorResponse(CurrentUserResultNotFoundException)
   @ApiErrorResponse(ReservationNotFoundException)
   async getReservationResults(
     @Param('reservationId', ParseIntPipe) reservationId: number,


### PR DESCRIPTION
## 💡 주요 변경사항

1. `CreateReservationResultDto` 에서 `currentUser nullable: true`로 수정
2. swagger와 custom exception에서 `CurrentUserResultNotFoundException` 제거
3. 미사용 error-code인 `CURRENT_USER_RESULT_NOT_FOUND` 제거
4. 이에 맞춰서 service 코드 수정했어요

## 🔍 리뷰어 가이드

swagger로 수동 테스트, 테스트 코드로 정상 작동 확인했습니다.

## 📎 관련 이슈 / 링크

#133 

## 🙋 기타 공유 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **버그 수정**
  * 예약 결과 조회 시, 현재 사용자의 예약 결과가 없는 경우 예외를 발생시키지 않고 null로 반환하도록 변경되었습니다.
  * 관련 API 문서에서 해당 필드가 nullable로 표시됩니다.
  * 현재 사용자 결과 관련 예외 및 오류 코드가 제거되었습니다.

* **테스트**
  * 현재 사용자 예약 결과가 없을 때 예외 대신 null 반환을 검증하는 테스트로 수정되었습니다.
  * 테스트 코드 내 중복 제거 및 검증 로직이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->